### PR TITLE
Add Dockerfile and GitHub Actions Publish Workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+./github/workflows
+.vscode
+.gitignore
+.pylintrc
+Dockerfile
+LICENSE
+README.md
+setup.cfg

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -17,6 +17,8 @@ jobs:
       
     steps:
       - uses: actions/checkout@v4
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -28,12 +30,5 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-      
-      - name: Log in to GitHub Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-        #
-      - name: Push image
-        run: |
-          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
-          docker tag $IMAGE_NAME $IMAGE_ID:latest
-          docker push $IMAGE_ID:latest
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME:latest

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
 
-env:
-  IMAGE_NAME: workbench-agent
-
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -31,4 +28,4 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME:latest
+          tags: ghcr.io/${{ github.repository_owner }}/workbench-agent:latest

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build Container Image
-        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+        run: docker build --platform linux/arm64,linux/amd64 . --file Dockerfile --tag $IMAGE_NAME
 
       - name: Log in to GitHub Container Registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,31 @@
+name: Publish Container Image to GHCR
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  IMAGE_NAME: workbench-agent
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Container Image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        #
+      - name: Push image
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+          docker tag $IMAGE_NAME $IMAGE_ID:latest
+          docker push $IMAGE_ID:latest

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -18,9 +18,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build Container Image
-        run: docker build --platform linux/arm64,linux/amd64 . --file Dockerfile --tag $IMAGE_NAME
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
+      - name: Build Multi-Platform Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+      
       - name: Log in to GitHub Container Registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
         #

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM cgr.dev/chainguard/python:latest-dev as builder
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt --user
+
+FROM cgr.dev/chainguard/python:latest
+WORKDIR /app
+COPY --from=builder /home/nonroot/.local/lib/python3.12/site-packages /home/nonroot/.local/lib/python3.12/site-packages
+COPY workbench-agent.py .
+ENTRYPOINT [ "python", "/app/workbench-agent.py" ]

--- a/workbench-agent.py
+++ b/workbench-agent.py
@@ -80,11 +80,11 @@ class Workbench:
 
     def upload_files(self, scan_code: str, path: str):
         """
-        Uploads a .fossid file to the Workbench using the API's Upload endpoint.
+        Uploads files to the Workbench using the API's File Upload endpoint.
 
         Args:
-            scan_code (str): The code of the scan where the hashes should be uploaded.
-            path (str): Path to the blind scan result (.fossid file).
+            scan_code (str): The scan code where the file or files will be uploaded.
+            path (str): Path to the file or files to upload.
         """
         name = base64.b64encode(os.path.basename(path).encode()).decode("utf-8")
         scan_code = base64.b64encode(scan_code.encode()).decode("utf-8")
@@ -106,7 +106,7 @@ class Workbench:
                     sys.exit(1)
         except IOError:
             # Error opening file
-            print(f"Failed to upload hashes for scan {scan_code}")
+            print(f"Failed to upload files to the scan {scan_code}.")
             print(traceback.print_exc())
             sys.exit(1)
 
@@ -134,7 +134,7 @@ class Workbench:
 
     def create_webapp_scan(self, scan_code: str, project_code: str = None) -> bool:
         """
-        Creates a new web application scan in the Workbench.
+        Creates a Scan in Workbench. The scan can optionally be created inside a Project.
 
         Args:
             scan_code (str): The unique identifier for the scan.
@@ -152,7 +152,7 @@ class Workbench:
                 "scan_code": scan_code,
                 "scan_name": scan_code,
                 "project_code": project_code,
-                "description": "Automatically created scan by Workbench Agent script.",
+                "description": "Scan created using the Workbench Agent.",
             },
         }
         response = self._send_request(payload)


### PR DESCRIPTION
Hi @cristianp-fossid,

This PR adds a Dockerfile for the Workbench Agent and also publishes it to GHCR.io any time code is merged into main. This version of the Workbench Agent does not include the CLI, so the final image ends up at around 80MB. :) 

Publishing it to GHCR also lets clients use this image without authenticating to the Quay registry.