### PR TITLE
Block --blind_scan related argument combos that are not supported with a clear error message

### DIFF
--- a/workbench-agent.py
+++ b/workbench-agent.py
@@ -1257,6 +1257,15 @@ def parse_cmdline_args():
     )
 
     args = parser.parse_args()
+
+    # block invalid combos
+    if args.blind_scan and args.run_dependency_analysis:
+        print("--run_dependency_analysis is not supported with --blind_scan")
+        sys.exit(1)
+    if args.blind_scan and args.run_only_dependency_analysis:
+        print("--run_only_dependency_analysis is not supported with --blind_scan")
+        sys.exit(1)
+
     return args
 
 

--- a/workbench-agent.py
+++ b/workbench-agent.py
@@ -1265,6 +1265,10 @@ def parse_cmdline_args():
     if args.blind_scan and args.run_only_dependency_analysis:
         print("--run_only_dependency_analysis is not supported with --blind_scan")
         sys.exit(1)
+    real_path = os.path.realpath(args.path)
+    if args.blind_scan and not os.path.isdir(real_path):
+        print("--path must be a directory when --blind_scan is used")
+        sys.exit(1)
 
     return args
 


### PR DESCRIPTION
Currently the combos in question are accepted but Workbench will not do what is expected:

1. `--run_dependency_analysis`: no dependencies will be found
2. `--path` is a *.zip file: zip file will be scanned instead of its contents.